### PR TITLE
Modify is_hex to be more *right*

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,7 +717,7 @@ True
 
 #### `is_hex(value)` -> bool
 
-Returns `True` if `value` is a valid hexidecimal encoded string of length >= 1.
+Returns `True` if `value` is a hexidecimal encoded string.
 
 ```python
 >>> is_hex('')
@@ -725,13 +725,13 @@ False
 >>> is_hex(b'')
 False
 >>> is_hex('0x')
-False
+True
 >>> is_hex(b'0x')
-False
+True
 >>> is_hex('0X')
-False
+True
 >>> is_hex(b'0X')
-False
+True
 >>> is_hex('1234567890abcdef')
 True
 >>> is_hex('0x1234567890abcdef')
@@ -740,8 +740,10 @@ True
 True
 >>> is_hex('0x1234567890AbCdEf')
 True
->>> is_hex('12345')  # odd length
-False
+>>> is_hex('12345')  # odd length is ok
+True
+>>> is_hex('0x12345')  # odd length is ok
+True
 >>> is_hex('123456__abcdef')  # non hex characters
 False
 ```

--- a/eth_utils/hexidecimal.py
+++ b/eth_utils/hexidecimal.py
@@ -50,8 +50,19 @@ def add_0x_prefix(value):
 
 
 def is_hex(value):
+    if not is_string(value):
+        return False
+    elif value.lower() in {b'0x', '0x'}:
+        return True
+
+    unprefixed_value = remove_0x_prefix(value)
+    if len(unprefixed_value) % 2 != 0:
+        value_to_decode = (b'0' if is_bytes(unprefixed_value) else '0') + unprefixed_value
+    else:
+        value_to_decode = unprefixed_value
+
     try:
-        value_as_bytes = codecs.decode(remove_0x_prefix(value), 'hex')
+        value_as_bytes = codecs.decode(value_to_decode, 'hex')
     except binascii.Error:
         return False
     except TypeError:

--- a/tests/hexidecimal-utils/test_is_hex.py
+++ b/tests/hexidecimal-utils/test_is_hex.py
@@ -12,20 +12,30 @@ from eth_utils import (
     (
         (b'', False),  # empty string
         ('', False),  # empty string
-        (b'0x', False),  # empty string
-        ('0x', False),  # empty string
-        (b'0X', False),  # empty string
-        ('0X', False),  # empty string
+        (b'0x', True),  # empty string
+        ('0x', True),  # empty string
+        (b'0X', True),  # empty string
+        ('0X', True),  # empty string
         ('abcdef1234567890', True),
         (b'abcdef1234567890', True),
         ('ABCDEF1234567890', True),
         (b'ABCDEF1234567890', True),
         ('AbCdEf1234567890', True),
         (b'aBcDeF1234567890', True),
-        ('12345', False),  # odd length
-        (b'12345', False),  # odd length
+        ('0xabcdef1234567890', True),
+        (b'0xabcdef1234567890', True),
+        ('0xABCDEF1234567890', True),
+        (b'0xABCDEF1234567890', True),
+        ('0xAbCdEf1234567890', True),
+        (b'0xaBcDeF1234567890', True),
+        ('12345', True),  # odd length
+        (b'12345', True),  # odd length
+        ('0x12345', True),  # odd length
+        (b'0x12345', True),  # odd length
         ('123456xx', False),  # non-hex character
         (b'123456xx', False),  # non-hex character
+        ('0x123456xx', False),  # non-hex character
+        (b'0x123456xx', False),  # non-hex character
     ),
 )
 def test_is_hex(value, expected):


### PR DESCRIPTION
### What was wrong?

`is_hex` had some surprising return values like:

```python
>>> is_hex('0x')
False
>>> is_hex('0x12345')  # odd length
False
```

### How was it fixed

Changed to accept both empty string hex values `0x` and odd-length hex values.